### PR TITLE
Fast fingerprinting

### DIFF
--- a/src/core/File.hh
+++ b/src/core/File.hh
@@ -42,20 +42,22 @@ struct File : std::enable_shared_from_this<File> {
 
   void fingerprint();
 
-  bool shouldSave();
+  bool shouldSave() const;
 
   void serialize(Serializer& serializer, db::File::Builder builder);
 
   std::shared_ptr<File> getLatestVersion();
 
   bool isModified() const;
+  
+  bool isLocal() const;
 
   /****** Getters and setters ******/
 
   const std::string& getPath() const { return _path; }
 
   db::FileType getType() const { return _type; }
-  bool isPipe() { return getType() == db::FileType::PIPE; }
+  bool isPipe() const { return getType() == db::FileType::PIPE; }
 
   void setMode(uint16_t mode) { _mode = mode; }
   uint16_t getMode() const { return _mode; }

--- a/src/ui/log.hh
+++ b/src/ui/log.hh
@@ -22,11 +22,11 @@
  */
 class logger {
  private:
-  log_level _level;  // Should the program abort when the log message is finished?
-  bool _done;        // Is this the final command in the log output?
+  LogLevel _level;  // Should the program abort when the log message is finished?
+  bool _done;       // Is this the final command in the log output?
 
  public:
-  logger(const char* source_file, int source_line, log_level level) : _level(level), _done(true) {
+  logger(const char* source_file, int source_line, LogLevel level) : _level(level), _done(true) {
     // Only log things if they're at or above our log threshold
     if (_level >= options.log_threshold) {
       // Print source information, if enabled
@@ -37,13 +37,13 @@ class logger {
 
       // Set the log color
       if (options.color_output) {
-        if (_level == log_level::Verbose) {
+        if (_level == LogLevel::Verbose) {
           std::cerr << COLOR_VERBOSE;
-        } else if (_level == log_level::Info) {
+        } else if (_level == LogLevel::Info) {
           std::cerr << COLOR_INFO;
-        } else if (_level == log_level::Warning) {
+        } else if (_level == LogLevel::Warning) {
           std::cerr << COLOR_WARNING;
-        } else if (_level == log_level::Fatal) {
+        } else if (_level == LogLevel::Fatal) {
           std::cerr << COLOR_FATAL;
         }
       }
@@ -59,13 +59,13 @@ class logger {
   ~logger() {
     if (_done) {
       // If this log message is being displayed, end color output and print a newline
-      if (_level >= options.log_threshold) {
+      if (static_cast<int>(_level) >= static_cast<int>(options.log_threshold)) {
         if (options.color_output) std::cerr << COLOR_END;
         std::cerr << "\n";
       }
 
       // If this log is a fatal
-      if (_level == log_level::Fatal) exit(2);
+      if (_level == LogLevel::Fatal) exit(2);
     }
   }
 
@@ -94,10 +94,10 @@ class logger {
 };
 
 // Set macros for explicit logging
-#define LOG logger(__FILE__, __LINE__, log_level::Verbose)
-#define INFO logger(__FILE__, __LINE__, log_level::Info)
-#define WARN logger(__FILE__, __LINE__, log_level::Warning)
-#define FAIL logger(__FILE__, __LINE__, log_level::Fatal)
+#define LOG logger(__FILE__, __LINE__, LogLevel::Verbose)
+#define INFO logger(__FILE__, __LINE__, LogLevel::Info)
+#define WARN logger(__FILE__, __LINE__, LogLevel::Warning)
+#define FAIL logger(__FILE__, __LINE__, LogLevel::Fatal)
 
 // Define an ASSERT macro, but disable checks when NDEBUG is defined
 #ifdef NDEBUG
@@ -107,14 +107,20 @@ class logger {
 #endif
 
 // Define conditional logging macros
-#define INFO_IF(cond) if (cond) INFO
-#define INFO_UNLESS(cond) if (!(cond)) INFO
+#define INFO_IF(cond) \
+  if (cond) INFO
+#define INFO_UNLESS(cond) \
+  if (!(cond)) INFO
 
-#define WARN_IF(cond) if (cond) WARN
-#define WARN_UNLESS(cond) if (!(cond)) WARN
+#define WARN_IF(cond) \
+  if (cond) WARN
+#define WARN_UNLESS(cond) \
+  if (!(cond)) WARN
 
-#define FAIL_IF(cond) if (cond) FAIL
-#define FAIL_UNLESS(cond) if (!(cond)) FAIL
+#define FAIL_IF(cond) \
+  if (cond) FAIL
+#define FAIL_UNLESS(cond) \
+  if (!(cond)) FAIL
 
 // Define a shortcut for printing the error message corresponding to the current errno
 #define ERR strerror(errno)

--- a/src/ui/options.hh
+++ b/src/ui/options.hh
@@ -5,13 +5,14 @@
 
 #include "ui/log.hh"
 
-enum log_level : int { Verbose = 0, Info = 1, Warning = 2, Fatal = 3 };
+enum class LogLevel { Verbose = 0, Info = 1, Warning = 2, Fatal = 3 };
+
+enum class FingerprintLevel { None, Local, All };
 
 /**
  * Struct to hold command-line options for Dodo, with defaults set here
  */
 struct dodo_options {
-  bool use_fingerprints = true;
   std::set<std::string> explicitly_changed;
   std::set<std::string> explicitly_unchanged;
   bool dry_run = false;
@@ -20,8 +21,13 @@ struct dodo_options {
   bool show_sysfiles = false;
   bool show_collapsed = true;
 
+  // Fingerprint local or created files by default
+  FingerprintLevel fingerprint = FingerprintLevel::Local;
+
   // Only display log messages that are fatal
-  log_level log_threshold = log_level::Fatal;
+  LogLevel log_threshold = LogLevel::Fatal;
+
+  // Color log output by defaulz
   bool color_output = true;
 
   // Do not display source locations with log messages


### PR DESCRIPTION
Fingerprint only local and created files by default. Added a command line option to fingerprint all files or no files, with some associated cleanup of the log level option as well.