### PR TITLE
Fix build on Arch Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC  = clang
 CXX = clang++
 AR = ar
 MAKEFLAGS += -j$(shell ls /sys/devices/system/cpu | grep -E cpu\[0-9\]+ | wc -l)
-ARCH := $(shell uname -p)
+ARCH := $(shell uname -m)
 
 # Install prefix
 PREFIX ?= /usr

--- a/Rikerfile
+++ b/Rikerfile
@@ -2,7 +2,7 @@
 
 # Set up compilation options
 PREFIX="self-build"
-ARCH=`uname -p`
+ARCH=`uname -m`
 BLAKE3="$PWD/deps/BLAKE3/c"
 CFLAGS="-O3 -g -fstandalone-debug -Wall -Wfatal-errors -Isrc/common -Isrc/rkr -I$BLAKE3 -I$PREFIX"
 CXXFLAGS="$CFLAGS --std=c++17 -Ideps/CLI11/include -Ideps/fmt/include -DFMT_HEADER_ONLY"

--- a/tests/graph/05-show-all.t
+++ b/tests/graph/05-show-all.t
@@ -14,15 +14,15 @@ Generate graph output in unrendered dot format
   $ rkr graph --no-render
 
 Check the graph source for /bin/sh. We should not find it.
-  $ grep -oE "/bin/(da)?sh" out.dot
+  $ grep -oE "/bin/([bd]a)?sh" out.dot
   [1]
 
 Generate graph output again, this time including all files
   $ rkr graph -a --no-render
 
 Check the graph source for /bin/sh. Now it should be there.
-  $ grep -oE "/bin/(da)?sh" out.dot
-  /bin/(da)?sh (re)
+  $ grep -oE "/bin/([bd]a)?sh" out.dot
+  /bin/([bd]a)?sh (re)
 
 Clean up
   $ rm -rf .rkr output out.dot


### PR DESCRIPTION
With these patches, riker builds on Arch Linux. Unfortunately, there's still four test failures where it's not clear to me what's wrong:

```
$ make test                                                                                                    :(
Running tests using rkr in /home/lukas/src/riker/debug/bin
             ABbuild .....
             addfile .
     alter-if-exists ..
basic-nondeterminism .
         build-error !!!
        build-error2 .......
           buildfile ..
                  cd ...
   conflicting-files .
            coredump s
      creat-dir-open .
     creat-excl-path .
                 csv .
        edit-comment .
          evil-links ..
g++-prebuilt-modules sssss
     g++-std-modules ssss
               graph .....
               hello ........
                list ......
                make ..
            makelink ...
  metadata-maychange ..
               mkdir ....
         no-fixpoint ....
   nofollow-symlinks .
             o_creat .
    openat-directory .
       paper-example !
            pdflatex ......
               pipes ...
              pipes2 ...
            readlink ...
      rebuild-commit ..
   recursive-torture s
              rename ......
           rm-append s
               rmdir ...
                skip .....
               stats ...
             symlink ..
               touch ..
          whitespace .
            wildcard .....
Ran 125 tests, 109 passed, 12 skipped, 4 failed.
```