### PR TITLE
fix(data/Trace): Remove code unlinking temp file

### DIFF
--- a/src/rkr/data/Trace.cc
+++ b/src/rkr/data/Trace.cc
@@ -88,6 +88,9 @@ TraceFile TraceFile::create() noexcept {
         return result;
       }
 
+      // Save the temporary path so we can clean it up later
+      result.tmp_path = tempname;
+
     } else {
       WARN << "Failed to open temporary file: " << ERR;
       return result;
@@ -207,6 +210,11 @@ void TraceFile::destroy() noexcept {
   if (data != nullptr && data != MAP_FAILED) {
     munmap(data, length);
     data = nullptr;
+  }
+
+  // If there's a leftover temporary file, try to clean it up (no fallback if unlink fails)
+  if (tmp_path.has_value()) {
+    ::unlink(tmp_path.value().c_str());
   }
 
   length = 0;
@@ -772,8 +780,7 @@ struct Record<RecordType::PathRef> {
 template <>
 void TraceReader::handleRecord<RecordType::PathRef>(IRSink& sink) noexcept {
   const auto& data = takeRecord<RecordType::PathRef>();
-  sink.pathRef(*this, _current_command, data.base, getString(data.path), data.flags,
-               data.output);
+  sink.pathRef(*this, _current_command, data.base, getString(data.path), data.flags, data.output);
 }
 
 // Write a PathRef record to the output trace
@@ -980,8 +987,7 @@ struct Record<RecordType::UpdateContent> {
 template <>
 void TraceReader::handleRecord<RecordType::UpdateContent>(IRSink& sink) noexcept {
   const auto& data = takeRecord<RecordType::UpdateContent>();
-  sink.updateContent(*this, _current_command, data.ref,
-                     getContentVersion(data.version));
+  sink.updateContent(*this, _current_command, data.ref, getContentVersion(data.version));
 }
 
 // Write an UpdateContent record to the output trace
@@ -1034,8 +1040,7 @@ struct Record<RecordType::RemoveEntry> {
 template <>
 void TraceReader::handleRecord<RecordType::RemoveEntry>(IRSink& sink) noexcept {
   const auto& data = takeRecord<RecordType::RemoveEntry>();
-  sink.removeEntry(*this, _current_command, data.dir, getString(data.name),
-                   data.target);
+  sink.removeEntry(*this, _current_command, data.dir, getString(data.name), data.target);
 }
 
 // Write a RemoveEntry record to the output trace

--- a/src/rkr/data/Trace.cc
+++ b/src/rkr/data/Trace.cc
@@ -88,11 +88,6 @@ TraceFile TraceFile::create() noexcept {
         return result;
       }
 
-      // Unlink the temporary file so it is anonymous
-      if (::unlink(tempname)) {
-        WARN << "Failed to unlink temporary file: " << ERR;
-      }
-
     } else {
       WARN << "Failed to open temporary file: " << ERR;
       return result;

--- a/src/rkr/data/Trace.hh
+++ b/src/rkr/data/Trace.hh
@@ -35,6 +35,9 @@ struct TraceFile {
   size_t pos = 0;           //< The current position in the mapped file
   uint8_t* data = nullptr;  //< A pointer to the beginning of the mapped file
 
+  /// A path to this file that should be unlinked when the object is destroyed
+  std::optional<std::string> tmp_path;
+
   /// Open a trace file at a given path for reading
   static TraceFile open(std::string path) noexcept;
 


### PR DESCRIPTION
Fixes #45, one can not relink a non-O_TMPFILE outside of debugfs, so when we unlink the tempfile that's created after O_TMPFILE fails, it will crash Riker as it can not be relinked later.